### PR TITLE
Add rectangular mode + Repo setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-avatar-edit",
+  "name": "@impargo/react-avatar-edit",
   "version": "0.8.3",
   "description": "ReactJS component to upload, crop, and preview avatars",
   "main": "lib/react-avatar.js",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kirill3333/react-avatar.git"
+    "url": "git+https://github.com/impargo/react-avatar.git"
   },
   "author": {
     "name": "Kirill Novikov",
@@ -19,14 +19,14 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/kirill3333/react-avatar/issues"
+    "url": "https://github.com/impargo/react-avatar/issues"
   },
   "keywords": [
     "avatar",
     "react",
     "canvas"
   ],
-  "homepage": "https://github.com/kirill3333/react-avatar#readme",
+  "homepage": "https://github.com/impargo/react-avatar#readme",
   "dependencies": {
     "konva": "2.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@impargo/react-avatar-edit",
-  "version": "0.8.3",
+  "version": "1.0",
   "description": "ReactJS component to upload, crop, and preview avatars",
   "main": "lib/react-avatar.js",
   "types": "src/avatar.d.ts",
@@ -17,6 +17,9 @@
     "name": "Kirill Novikov",
     "email": "kirill3333@inbox.ru"
   },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  }, 
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/impargo/react-avatar/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@impargo/react-avatar-edit",
-  "version": "1.0",
+  "version": "1.0.0",
   "description": "ReactJS component to upload, crop, and preview avatars",
   "main": "lib/react-avatar.js",
   "types": "src/avatar.d.ts",

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -264,18 +264,18 @@ class Avatar extends React.Component {
     stage.add(layer);
 
     const scaledRadius = (scale = 0) => crop.width() - scale;
-    const isLeftCorner = () => crop.x() < 1;
-    const calcLeft = () => 0;
-    const isTopCorner = () => crop.y() < 1;
-    const calcTop = () => 0;
-    const isRightCorner = scale => crop.x() + scaledRadius(scale) > stage.width();
-    const calcRight = () => stage.width() - crop.width() - 1;
-    const isBottomCorner = scale => crop.y() + scaledRadius(scale) > stage.height();
-    const calcBottom = () => stage.height() - crop.height() - 1;
+    const isLeftCorner = () => crop.x() - crop.width()/2 < 1;
+    const calcLeft = () => crop.width()/2;
+    const isTopCorner = () => crop.y() - crop.height()/2 < 1;
+    const calcTop = () => crop.height()/2;
+    const isRightCorner = scale => crop.x() + scaledRadius(scale)/2 > stage.width();
+    const calcRight = () => stage.width() - crop.width()/2 - 1;
+    const isBottomCorner = scale => crop.y() + scaledRadius(scale)/2 > stage.height();
+    const calcBottom = () => stage.height() - crop.height()/2 - 1;
     const isNotOutOfScale = scale => !isLeftCorner(scale) && !isRightCorner(scale) && !isBottomCorner(scale) && !isTopCorner(scale);
     const calcScaleRadius = scale => scaledRadius(scale) >= this.minCropRadius ? scale : crop.width() - this.minCropRadius;
-    const calcResizerX = x => x + (crop.width());
-    const calcResizerY = y => y;
+    const calcResizerX = x => this.round ? x + (crop.width()/2 * 0.86) : x + crop.width() / 2 - 8;
+    const calcResizerY = y => this.round ? y - (crop.height()/2 * 0.5) : y - crop.height() / 2 - 8;
     const moveResizer = (x, y) => {
       resize.x(calcResizerX(x));
       resize.y(calcResizerY(y));
@@ -296,6 +296,11 @@ class Avatar extends React.Component {
       cropStroke.height(cropStroke.height() - calcScaleRadius(scale));
       crop.width(crop.width() - calcScaleRadius(scale));
       crop.height(crop.height() - calcScaleRadius(scale));
+      crop.offsetX(crop.width()/2)
+      crop.offsetY(crop.height()/2)
+      cropStroke.offsetX(cropStroke.width()/2)
+      cropStroke.offsetY(cropStroke.height()/2)
+      crop.setFillPatternOffset({ x: (crop.x() - crop.width()/2) / this.scale, y: (crop.y() - crop.height()/2) / this.scale });
       resize.fire('resize')
     };
 
@@ -308,7 +313,7 @@ class Avatar extends React.Component {
       const x = isLeftCorner() ? calcLeft() : (isRightCorner() ? calcRight() : crop.x());
       const y = isTopCorner() ? calcTop() : (isBottomCorner() ? calcBottom() : crop.y());
       moveResizer(x, y);
-      crop.setFillPatternOffset({ x: x / this.scale, y: y / this.scale });
+      crop.setFillPatternOffset({ x: (x - crop.width()/2) / this.scale, y: (y - crop.height()/2) / this.scale });
       crop.x(x);
       cropStroke.x(x);
       crop.y(y);
@@ -387,13 +392,15 @@ class Avatar extends React.Component {
     return new Konva.Rect({
       x: this.halfWidth,
       y: this.halfHeight,
+      offsetX: this.cropRadius,
+      offsetY: this.cropRadius,
       height: this.cropRadius * 2,
       width: this.cropRadius * 2,
       fillPatternImage: this.image,
       cornerRadius: this.round ? this.halfWidth : 0,
       fillPatternOffset: {
-        x: this.halfWidth / this.scale,
-        y: this.halfHeight / this.scale
+        x: (this.halfWidth - this.cropRadius) / this.scale,
+        y: (this.halfHeight - this.cropRadius) / this.scale
       },
       fillPatternScale: {
         x: this.scale,
@@ -412,6 +419,8 @@ class Avatar extends React.Component {
       y: this.halfHeight,
       height: this.cropRadius * 2,
       width: this.cropRadius * 2,
+      offsetX: this.cropRadius,
+      offsetY: this.cropRadius,
       cornerRadius: this.round ? this.halfWidth : 0,
       stroke: this.cropColor,
       strokeWidth: this.lineWidth,
@@ -423,8 +432,8 @@ class Avatar extends React.Component {
 
   initResize() {
     return new Konva.Rect({
-      x: this.halfWidth + this.cropRadius,
-      y: this.halfHeight + this.cropRadius,
+      x: this.round ? this.halfWidth + (this.cropRadius * 0.86) : this.halfWidth + this.cropRadius - 8,
+      y: this.round ? this.halfHeight - (this.cropRadius * 0.5) : this.halfHeight - this.cropRadius - 8,
       width: 16,
       height: 16,
       draggable: true,
@@ -439,8 +448,8 @@ class Avatar extends React.Component {
 
   initResizeIcon() {
     return new Konva.Path({
-      x: this.halfWidth + this.cropRadius * 2,
-      y: this.halfHeight,
+      x: this.round ? this.halfWidth + (this.cropRadius * 0.86) : this.halfWidth + this.cropRadius - 8,
+      y: this.round ? this.halfHeight - (this.cropRadius * 0.5) : this.halfHeight - this.cropRadius - 8,
       data: 'M47.624,0.124l12.021,9.73L44.5,24.5l10,10l14.661-15.161l9.963,12.285v-31.5H47.624z M24.5,44.5   L9.847,59.653L0,47.5V79h31.5l-12.153-9.847L34.5,54.5L24.5,44.5z',
       fill: this.cropColor,
       scale: {

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -293,9 +293,9 @@ class Avatar extends React.Component {
     const onScaleCallback = (scaleY) => {
       const scale = scaleY > 0 || isNotOutOfScale(scaleY) ? scaleY : 0;
       cropStroke.width(cropStroke.width() - calcScaleRadius(scale));
-      cropStroke.height(cropStroke.height() - calcScaleRadius(scale));
+      cropStroke.height(cropStroke.width());
       crop.width(crop.width() - calcScaleRadius(scale));
-      crop.height(crop.height() - calcScaleRadius(scale));
+      crop.height(crop.width());
       crop.offsetX(crop.width()/2)
       crop.offsetY(crop.height()/2)
       cropStroke.offsetX(cropStroke.width()/2)

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -258,37 +258,39 @@ class Avatar extends React.Component {
 
     stage.add(layer);
 
-    const scaledRadius = (scale = 0) => crop.radius() - scale;
-    const isLeftCorner = scale => crop.x() - scaledRadius(scale) < 0;
-    const calcLeft = () => crop.radius() + 1;
-    const isTopCorner = scale => crop.y() - scaledRadius(scale) < 0;
-    const calcTop = () => crop.radius() + 1;
+    const scaledRadius = (scale = 0) => crop.width() - scale;
+    const isLeftCorner = () => crop.x() < 1;
+    const calcLeft = () => 0;
+    const isTopCorner = () => crop.y() < 1;
+    const calcTop = () => 0;
     const isRightCorner = scale => crop.x() + scaledRadius(scale) > stage.width();
-    const calcRight = () => stage.width() - crop.radius() - 1;
+    const calcRight = () => stage.width() - crop.width() - 1;
     const isBottomCorner = scale => crop.y() + scaledRadius(scale) > stage.height();
-    const calcBottom = () => stage.height() - crop.radius() - 1;
+    const calcBottom = () => stage.height() - crop.height() - 1;
     const isNotOutOfScale = scale => !isLeftCorner(scale) && !isRightCorner(scale) && !isBottomCorner(scale) && !isTopCorner(scale);
-    const calcScaleRadius = scale => scaledRadius(scale) >= this.minCropRadius ? scale : crop.radius() - this.minCropRadius;
-    const calcResizerX = x => x + (crop.radius() * 0.86);
-    const calcResizerY = y => y - (crop.radius() * 0.5);
+    const calcScaleRadius = scale => scaledRadius(scale) >= this.minCropRadius ? scale : crop.width() - this.minCropRadius;
+    const calcResizerX = x => x + (crop.width());
+    const calcResizerY = y => y;
     const moveResizer = (x, y) => {
-      resize.x(calcResizerX(x) - 8);
-      resize.y(calcResizerY(y) - 8);
-      resizeIcon.x(calcResizerX(x) - 8);
-      resizeIcon.y(calcResizerY(y) - 10)
+      resize.x(calcResizerX(x));
+      resize.y(calcResizerY(y));
+      resizeIcon.x(calcResizerX(x));
+      resizeIcon.y(calcResizerY(y))
     };
 
     const getPreview = () => crop.toDataURL({
-      x: crop.x() - crop.radius(),
-      y: crop.y() - crop.radius(),
-      width: crop.radius() * 2,
-      height: crop.radius() * 2
+      x: crop.x() - crop.width(),
+      y: crop.y() - crop.width(),
+      width: crop.width() * 2,
+      height: crop.height() * 2
     });
 
     const onScaleCallback = (scaleY) => {
       const scale = scaleY > 0 || isNotOutOfScale(scaleY) ? scaleY : 0;
-      cropStroke.radius(cropStroke.radius() - calcScaleRadius(scale));
-      crop.radius(crop.radius() - calcScaleRadius(scale));
+      cropStroke.width(cropStroke.width() - calcScaleRadius(scale));
+      cropStroke.height(cropStroke.height() - calcScaleRadius(scale));
+      crop.width(crop.width() - calcScaleRadius(scale));
+      crop.height(crop.height() - calcScaleRadius(scale));
       resize.fire('resize')
     };
 
@@ -377,10 +379,11 @@ class Avatar extends React.Component {
   }
 
   initCrop() {
-    return new Konva.Circle({
+    return new Konva.Rect({
       x: this.halfWidth,
       y: this.halfHeight,
-      radius: this.cropRadius,
+      height: this.cropRadius * 2,
+      width: this.cropRadius * 2,
       fillPatternImage: this.image,
       fillPatternOffset: {
         x: this.halfWidth / this.scale,
@@ -398,10 +401,11 @@ class Avatar extends React.Component {
   }
 
   initCropStroke() {
-    return new Konva.Circle({
+    return new Konva.Rect({
       x: this.halfWidth,
       y: this.halfHeight,
-      radius: this.cropRadius,
+      height: this.cropRadius * 2,
+      width: this.cropRadius * 2,
       stroke: this.cropColor,
       strokeWidth: this.lineWidth,
       strokeScaleEnabled: true,
@@ -428,8 +432,8 @@ class Avatar extends React.Component {
 
   initResizeIcon() {
     return new Konva.Path({
-      x: this.halfWidth + this.cropRadius * 0.86 - 8,
-      y: this.halfHeight + this.cropRadius * -0.5 - 10,
+      x: this.halfWidth + this.cropRadius * 2,
+      y: this.halfHeight,
       data: 'M47.624,0.124l12.021,9.73L44.5,24.5l10,10l14.661-15.161l9.963,12.285v-31.5H47.624z M24.5,44.5   L9.847,59.653L0,47.5V79h31.5l-12.153-9.847L34.5,54.5L24.5,44.5z',
       fill: this.cropColor,
       scale: {

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -11,6 +11,7 @@ class Avatar extends React.Component {
 
   static defaultProps = {
     shadingColor: 'grey',
+    round: true,
     shadingOpacity: 0.6,
     cropColor: 'white',
     closeIconColor: 'white',
@@ -61,6 +62,10 @@ class Avatar extends React.Component {
       lastMouseY: 0,
       showLoader: !(this.props.src || this.props.img)
     }
+  }
+  
+  get round() {
+    return this.props.round
   }
 
   get lineWidth() {
@@ -385,6 +390,7 @@ class Avatar extends React.Component {
       height: this.cropRadius * 2,
       width: this.cropRadius * 2,
       fillPatternImage: this.image,
+      cornerRadius: this.round ? this.halfWidth : 0,
       fillPatternOffset: {
         x: this.halfWidth / this.scale,
         y: this.halfHeight / this.scale
@@ -406,6 +412,7 @@ class Avatar extends React.Component {
       y: this.halfHeight,
       height: this.cropRadius * 2,
       width: this.cropRadius * 2,
+      cornerRadius: this.round ? this.halfWidth : 0,
       stroke: this.cropColor,
       strokeWidth: this.lineWidth,
       strokeScaleEnabled: true,
@@ -416,8 +423,8 @@ class Avatar extends React.Component {
 
   initResize() {
     return new Konva.Rect({
-      x: this.halfWidth + this.cropRadius * 0.86 - 8,
-      y: this.halfHeight + this.cropRadius * -0.5 - 8,
+      x: this.halfWidth + this.cropRadius,
+      y: this.halfHeight + this.cropRadius,
       width: 16,
       height: 16,
       draggable: true,


### PR DESCRIPTION
### Description
Add rectangular mode that enables us to have rectangular avatars.
passing the prop `round={false}` would make the cropping segment round again as before.