### PR TITLE
Fix out of stage issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@impargo/react-avatar-edit",
-  "version": "1.0.8",
+  "version": "1.0.81",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@impargo/react-avatar-edit",
-  "version": "1.0.81",
+  "version": "1.0.82",
   "description": "ReactJS component to upload, crop, and preview avatars",
   "main": "lib/react-avatar.js",
   "types": "src/avatar.d.ts",

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -278,15 +278,17 @@ class Avatar extends React.Component {
     stage.add(layer);
 
     const scaledRadius = (scale = 0) => crop.width() - scale;
-    const isLeftCorner = () => crop.x() - crop.width()/2 < 1;
-    const calcLeft = () => crop.width()/2;
-    const isTopCorner = () => crop.y() - crop.height()/2 < 1;
-    const calcTop = () => crop.height()/2;
-    const isRightCorner = () => crop.x() + crop.width()/2 > stage.width();
-    const calcRight = () => stage.width() - crop.width()/2 - 1;
-    const isBottomCorner = () => crop.y() + crop.height()/2 > stage.height();
-    const calcBottom = () => stage.height() - crop.height()/2 - 1;
-    const isNotOutOfScale = scale => !isLeftCorner(scale) && !isRightCorner(scale) && !isBottomCorner(scale) && !isTopCorner(scale);
+    const isLeftCorner = () => crop.x() - crop.width()/2 - 3 < 0;
+    const calcLeft = () => crop.width()/2 + 5;
+    const isTopCorner = () => crop.y() - crop.height()/2 - 3 < 0;
+    const calcTop = () => crop.height()/2 + 5;
+    const isRightCorner = () => crop.x() + crop.width()/2 > stage.width() - 10;
+    const calcRight = () => stage.width() - crop.width()/2 - 5;
+    const isBottomCorner = () => crop.y() + crop.height()/2 > stage.height() - 10;
+    const calcBottom = () => stage.height() - crop.height()/2 - 5;
+    const isNotOutOfScaleY = scale => !isBottomCorner(scale) && !isTopCorner(scale);
+    const isNotOutOfScaleX = scale => !isLeftCorner(scale) && !isRightCorner(scale)
+    const isNotOutOfScale = scale => isNotOutOfScaleX(scale) && isNotOutOfScaleY(scale)
     const isWithinaspectRatio = (aspectRatio) => {
       return aspectRatio >= this.props.minaspectRatio && aspectRatio <= this.props.maxaspectRatio;
     }
@@ -306,7 +308,7 @@ class Avatar extends React.Component {
       x: crop.x() - crop.width()/2,
       y: crop.y() - crop.height()/2,
       width: crop.width(),
-      height: crop.height()
+      height: crop.height(),
     });
 
     const onScaleCallback = (scale) => {
@@ -315,7 +317,7 @@ class Avatar extends React.Component {
     };
     const onScaleCallbackX = (scaleX) => {
       const currentaspectRatio = crop.width() / crop.height()
-      let scale = scaleX > 0 || isNotOutOfScale(scaleX) ? scaleX : 0;
+      let scale = scaleX > 0 || isNotOutOfScaleX(scaleX) ? scaleX : 0;
       scale = (scale < 0 && currentaspectRatio >= this.props.maxaspectRatio) ? 0 : scale
       scale = (scale > 0 && currentaspectRatio <= this.props.minaspectRatio) ? 0 : scale
       cropStroke.width(cropStroke.width() - calcScaleRadius(scale));
@@ -329,7 +331,7 @@ class Avatar extends React.Component {
 
     const onScaleCallbackY = (scaleY) => {
       const currentaspectRatio = crop.width() / crop.height()
-      let scale = scaleY > 0 || isNotOutOfScale(scaleY) ? scaleY : 0;
+      let scale = scaleY > 0 || isNotOutOfScaleY(scaleY) ? scaleY : 0;
       scale = (scale > 0 && currentaspectRatio >= this.props.maxaspectRatio) ? 0 : scale
       scale = (scale < 0 && currentaspectRatio <= this.props.minaspectRatio) ? 0 : scale
       cropStroke.height(cropStroke.height() - calcScaleRadius(scale));

--- a/src/avatar.jsx
+++ b/src/avatar.jsx
@@ -317,7 +317,8 @@ class Avatar extends React.Component {
     };
     const onScaleCallbackX = (scaleX) => {
       const currentaspectRatio = crop.width() / crop.height()
-      let scale = scaleX > 0 || isNotOutOfScaleX(scaleX) ? scaleX : 0;
+      const isNotOutOfScaleFn = this.props.round ? isNotOutOfScale : isNotOutOfScaleX
+      let scale = scaleX > 0 || isNotOutOfScaleFn(scaleX) ? scaleX : 0;
       scale = (scale < 0 && currentaspectRatio >= this.props.maxaspectRatio) ? 0 : scale
       scale = (scale > 0 && currentaspectRatio <= this.props.minaspectRatio) ? 0 : scale
       cropStroke.width(cropStroke.width() - calcScaleRadius(scale));
@@ -331,7 +332,8 @@ class Avatar extends React.Component {
 
     const onScaleCallbackY = (scaleY) => {
       const currentaspectRatio = crop.width() / crop.height()
-      let scale = scaleY > 0 || isNotOutOfScaleY(scaleY) ? scaleY : 0;
+      const isNotOutOfScaleFn = this.props.round ? isNotOutOfScale : isNotOutOfScaleY
+      let scale = scaleY > 0 || isNotOutOfScaleFn(scaleY) ? scaleY : 0;
       scale = (scale > 0 && currentaspectRatio >= this.props.maxaspectRatio) ? 0 : scale
       scale = (scale < 0 && currentaspectRatio <= this.props.minaspectRatio) ? 0 : scale
       cropStroke.height(cropStroke.height() - calcScaleRadius(scale));


### PR DESCRIPTION
- [x] Important If one side of the selected cropping area (width or height) spans 100% of the uploaded image the other side cannot be increased anymore. This makes it almost impossible to select the whole uploaded image even if the aspect ratio is fine.
- [x] Less important If the width spans 100% of the uploaded image it's impossible to click on the borders anymore to make the width smaller.
- [x] Can be ignore If you drag the selected cropping area outside of the image it wraps.

related issues:
https://github.com/impargo/impargo-apps/pull/4715